### PR TITLE
feat: Dify chatbot + UI polish

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,24 @@
+export async function POST(req: Request) {
+  const { message, conversationId } = await req.json();
+
+  const res = await fetch('https://api.dify.ai/v1/chat-messages', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.DIFY_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      inputs: {},
+      query: message,
+      conversation_id: conversationId || '',
+      response_mode: 'blocking',
+      user: 'portfolio-visitor',
+    }),
+  });
+
+  const data = await res.json();
+  return Response.json({
+    answer: data.answer,
+    conversationId: data.conversation_id,
+  });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -99,18 +99,6 @@ p {
   transform: translateY(0) scale(1);
 }
 
-/* ─── Breathing dot ──────────────────────────────────────────────────────── */
-@keyframes breathe {
-  0%,
-  100% {
-    opacity: 0.5;
-    transform: scale(0.75);
-  }
-  50% {
-    opacity: 1;
-    transform: scale(1.25);
-  }
-}
 
 /* ─── Hero entry animations ──────────────────────────────────────────────── */
 @keyframes fadeUp {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import { Inter, Playfair_Display } from 'next/font/google';
 
 import { I18nProvider } from '@/components/i18n/I18nProvider';
+import { ChatBot } from '@/components/ui/ChatBot';
 import { IconFonts } from '@/components/ui/IconFonts';
 
 const fontDisplay = Playfair_Display({
@@ -39,6 +40,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     >
       <body>
         <I18nProvider>{children}</I18nProvider>
+        <ChatBot />
         <IconFonts />
       </body>
     </html>

--- a/components/section/LifeSection.tsx
+++ b/components/section/LifeSection.tsx
@@ -669,16 +669,13 @@ function MobileMoreGrid() {
                   </div>
                 )}
                 <div
-                  className="absolute inset-x-0 bottom-0 px-3 pb-3 pt-6"
+                  className="absolute inset-x-0 bottom-0 px-3 pb-3 pt-8"
                   style={{
-                    background: `linear-gradient(to top, ${hobby.color} 0%, ${hobby.color}cc 50%, transparent 100%)`,
+                    background: `linear-gradient(to top, ${hobby.color}cc 0%, transparent 100%)`,
                   }}
                 >
                   <p className="font-serif text-xs text-white">
                     {t(`life.hobby.${hobby.id}.label`)}
-                  </p>
-                  <p className="mt-0.5 font-body text-[0.65rem] leading-[1.6] text-white/80">
-                    {t(`life.hobby.${hobby.id}.desc`)}
                   </p>
                 </div>
               </div>
@@ -948,10 +945,11 @@ export function LifeSection() {
                   )}
                 >
                   <span className="text-xs tracking-wide">{t(item.labelKey)}</span>
-                  <motion.span
-                    animate={{ scale: isActive ? 1 : 0.6, opacity: isActive ? 1 : 0.2 }}
-                    transition={{ type: 'spring', stiffness: 400, damping: 30 }}
-                    className="block h-1 w-1 rounded-full bg-olive"
+                  <span
+                    className={cn(
+                      'block h-1 w-1 rounded-full bg-olive transition-all duration-500 ease-out',
+                      isActive ? 'scale-100 opacity-100 animate-breathe' : 'scale-[0.6] opacity-20',
+                    )}
                   />
                 </button>
               );

--- a/components/ui/ChatBot.tsx
+++ b/components/ui/ChatBot.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import Image from 'next/image';
+import { useEffect, useRef, useState } from 'react';
+
+import { cn } from '@/lib/utils';
+import avatarImg from '@/public/images/avatar.png';
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+const BOUNCE_DELAYS = [
+  '[animation-delay:0ms]',
+  '[animation-delay:200ms]',
+  '[animation-delay:400ms]',
+];
+
+const INITIAL_MESSAGE: Message = {
+  role: 'assistant',
+  content: "Hi! I'm Selin's assistant. Ask me anything about her work, skills, or projects.",
+};
+
+export function ChatBot() {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([INITIAL_MESSAGE]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [conversationId, setConversationId] = useState('');
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) setTimeout(() => inputRef.current?.focus(), 80);
+  }, [open]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, loading]);
+
+  function reset() {
+    setMessages([INITIAL_MESSAGE]);
+    setConversationId('');
+  }
+
+  async function send() {
+    const text = input.trim();
+    if (!text || loading) return;
+
+    setInput('');
+    setMessages((prev) => [...prev, { role: 'user', content: text }]);
+    setLoading(true);
+
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text, conversationId }),
+      });
+      const data = await res.json();
+      setConversationId(data.conversationId || '');
+      setMessages((prev) => [...prev, { role: 'assistant', content: data.answer }]);
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        { role: 'assistant', content: 'Sorry, something went wrong. Please try again.' },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleKey(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  }
+
+  return (
+    <>
+      {/* Toggle button */}
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-label={open ? 'Close chat' : 'Open chat'}
+        className={cn(
+          'fixed bottom-6 right-6 z-50 flex h-11 w-11 items-center justify-center rounded-full',
+          open ? 'bg-ink text-white' : 'bg-white text-ink shadow-[0_2px_12px_rgba(0,0,0,0.12)]',
+          'transition-all duration-200 hover:scale-105 active:scale-95',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink/20 focus-visible:ring-offset-2',
+        )}
+      >
+        <span
+          className={cn(
+            'material-symbols-outlined text-[20px] absolute transition-all duration-300 ease-in-out',
+            open ? 'opacity-0 scale-50 rotate-90' : 'opacity-100 scale-100 rotate-0',
+          )}
+          aria-hidden
+        >
+          chat_bubble
+        </span>
+        <svg
+          width="13"
+          height="13"
+          viewBox="0 0 14 14"
+          fill="none"
+          aria-hidden
+          className={cn(
+            'absolute transition-all duration-300 ease-in-out',
+            open ? 'opacity-100 scale-100 rotate-0' : 'opacity-0 scale-50 -rotate-90',
+          )}
+        >
+          <path
+            d="M1 1l12 12M13 1L1 13"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+          />
+        </svg>
+      </button>
+
+      {/* Chat panel */}
+      {open && (
+        <div
+          className={cn(
+            'fixed bottom-[5rem] right-4 z-50',
+            'flex h-[520px] w-[calc(100vw-2rem)] max-w-[360px] flex-col overflow-hidden',
+            'rounded-2xl bg-[#F7F7F8]',
+            'animate-fade-up',
+            'shadow-[0_12px_48px_rgba(0,0,0,0.12),0_1px_4px_rgba(0,0,0,0.06)]',
+          )}
+        >
+          {/* Header */}
+          <div className="flex shrink-0 items-center justify-between bg-white px-5 py-4">
+            <div className="flex items-center gap-3">
+              <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full">
+                <Image src={avatarImg} alt="Selin" fill className="object-cover object-right" />
+              </div>
+              <div>
+                <p className="font-body text-[13px] font-semibold leading-tight text-ink">
+                  Selin&apos;s Bot
+                </p>
+                <p className="flex items-center gap-1.5 font-body text-sm text-ink/40">
+                  <span className="inline-block h-1.5 w-1.5 rounded-full bg-olive" />
+                  We&apos;re online
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-1">
+              <button
+                onClick={reset}
+                aria-label="Reset conversation"
+                className="flex h-8 w-8 items-center justify-center rounded-full text-ink/25 transition-colors hover:bg-ink/[0.05] hover:text-ink/50"
+              >
+                <span className="material-symbols-outlined text-xs" aria-hidden>
+                  restart_alt
+                </span>
+              </button>
+              <button
+                onClick={() => setOpen(false)}
+                aria-label="Close"
+                className="flex h-8 w-8 items-center justify-center rounded-full text-ink/25 transition-colors hover:bg-ink/[0.05] hover:text-ink/50"
+              >
+                <span className="material-symbols-outlined text-md" aria-hidden>
+                  close
+                </span>
+              </button>
+            </div>
+          </div>
+
+          {/* Messages */}
+          <div
+            className={cn(
+              'flex-1 space-y-3 overflow-y-auto px-4 py-4',
+              '[&::-webkit-scrollbar]:w-[5px]',
+              '[&::-webkit-scrollbar-track]:bg-transparent',
+              '[&::-webkit-scrollbar-track]:[margin-block:60px]',
+              '[&::-webkit-scrollbar-thumb]:rounded-full',
+              '[&::-webkit-scrollbar-thumb]:[background-color:rgba(0,0,0,0.12)]',
+              '[&::-webkit-scrollbar-thumb]:[min-height:30px]',
+            )}
+          >
+            {messages.map((m, i) => (
+              <div
+                key={i}
+                className={cn('flex', m.role === 'user' ? 'justify-end' : 'justify-start')}
+              >
+                <div
+                  className={cn(
+                    'max-w-[85%] font-body text-[13.5px] leading-relaxed',
+                    m.role === 'user'
+                      ? 'rounded-2xl rounded-br-sm bg-ink px-4 py-3 text-white'
+                      : 'rounded-2xl rounded-bl-sm bg-white px-4 py-3 text-ink shadow-[0_1px_4px_rgba(0,0,0,0.06)]',
+                  )}
+                >
+                  {m.content}
+                </div>
+              </div>
+            ))}
+
+            {loading && (
+              <div className="flex justify-start">
+                <div className="flex items-center gap-1 rounded-2xl rounded-bl-sm bg-white px-4 py-3 shadow-[0_1px_4px_rgba(0,0,0,0.06)]">
+                  {BOUNCE_DELAYS.map((delay, i) => (
+                    <span
+                      key={i}
+                      className={cn('h-1.5 w-1.5 animate-bounce rounded-full bg-ink/25', delay)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+            <div ref={bottomRef} />
+          </div>
+
+          {/* Input */}
+          <div className="shrink-0 bg-white px-4 py-4">
+            <div className="flex items-center gap-3 rounded-full bg-cream-lt/40 px-4 py-1.5">
+              <input
+                ref={inputRef}
+                type="text"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKey}
+                placeholder="Enter message…"
+                disabled={loading}
+                className="flex-1 bg-transparent font-body text-[13px] text-ink outline-none placeholder:text-ink/30 disabled:opacity-50"
+              />
+              <button
+                onClick={send}
+                disabled={loading || !input.trim()}
+                aria-label="Send"
+                className={cn(
+                  'shrink-0 text-ink/30 transition-all',
+                  'disabled:opacity-25 enabled:cursor-pointer enabled:hover:text-ink-lt enabled:hover:scale-110 enabled:active:scale-95',
+                )}
+              >
+                <span
+                  className="material-symbols-outlined text-xs "
+                  style={{ transform: 'rotate(-45deg)', display: 'inline-block' }}
+                  aria-hidden
+                >
+                  send
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/ui/IconFonts.tsx
+++ b/components/ui/IconFonts.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 
 const ICON_FONT_URLS = [
   'https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=swipe_right',
-  'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=close,menu',
+  'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap',
 ];
 
 export function IconFonts() {

--- a/components/ui/Nav.tsx
+++ b/components/ui/Nav.tsx
@@ -77,7 +77,7 @@ export function Nav() {
       <header
         style={{ width: '100dvw' }}
         className={cn(
-          'fixed left-0 top-0 z-50 flex items-center justify-between px-5  transition-all duration-300 md:hidden',
+          'fixed left-0 top-0 z-50 h-14 flex items-center justify-between px-5  transition-all duration-300 md:hidden',
           scrolled || menuOpen
             ? 'bg-white shadow-[0_2px_16px_rgba(28,25,23,0.08)]'
             : 'bg-white/80 backdrop-blur-sm',
@@ -86,9 +86,16 @@ export function Nav() {
         <a
           href="#"
           aria-label="Home"
-          className="flex h-9 w-9 overflow-hidden rounded-full transition-opacity hover:opacity-80 flex-shrink-0"
+          className="flex h-8 w-8 overflow-hidden rounded-full transition-opacity hover:opacity-80 flex-shrink-0"
           onClick={menuOpen ? closeMenu : undefined}
-        ></a>
+        >
+          <Image
+            src={sheroImg}
+            alt="avatar"
+            className="h-full w-full object-cover object-right"
+            placeholder="blur"
+          />
+        </a>
 
         {/* Mobile progress bar — bottom edge of header */}
         <div
@@ -103,7 +110,7 @@ export function Nav() {
           aria-expanded={menuOpen}
           className="flex h-9 w-9 items-center justify-center rounded-full transition-colors hover:bg-ink/[0.06]"
         >
-          <span className="material-symbols-outlined select-none text-ink text-base">
+          <span className="material-symbols-outlined select-none text-ink ">
             {menuOpen ? 'close' : 'menu'}
           </span>
         </button>
@@ -152,12 +159,9 @@ export function Nav() {
                       className={cn(
                         'absolute -bottom-1.5 left-1/2 h-1 w-1 -translate-x-1/2 rounded-full bg-olive transition-all duration-500 ease-out',
                         isActive
-                          ? 'scale-100 opacity-100'
+                          ? 'scale-100 opacity-100 animate-breathe'
                           : 'scale-0 opacity-0 group-hover:scale-75 group-hover:opacity-60',
                       )}
-                      style={
-                        isActive ? { animation: 'breathe 2.4s ease-in-out infinite' } : undefined
-                      }
                     />
                   </a>
                 </li>

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -56,18 +56,6 @@ export const workExperiences: WorkExperience[] = [
     role: 'Mid-Level Frontend Engineer · 中级前端工程师',
     location: 'Chengdu → Remote (AU clients)',
     body: '在全球技术咨询公司 CI&T 担任前端工程师，服务澳大利亚头部客户，涵盖旅游、保险等行业。深度参与三个核心项目的重构与迭代，在 Next.js、Turborepo、Storybook 等现代工程体系中积累了大型项目实战经验。',
-    highlights: [
-      '主导 TravelAssociates 平台全量迁移，适配 Next.js + Turborepo 架构，按时交付关键前端功能',
-      '基于 Storybook 搭建标准化 UI 组件库，实现与 Figma 设计稿 100% 还原，统一全站视觉规范',
-      '优化关键渲染路径，Lighthouse SEO 达满分 100/100，Performance 达 89/100',
-      '使用 Framer Motion 实现品牌级高保真交互动效，提升用户参与度并保障跨端稳定性',
-      '在 Flight Centre Lerna Monorepo 中开发可复用业务组件，打通 Drupal Headless CMS 与前端映射层，支持编辑器拖拽建页',
-      '集成 AWS Lambda + Elasticsearch Serverless BFF，为门店搜索功能提供高性能数据聚合，编写并维护 OpenAPI (Swagger) 规范',
-      '主导 Ticket 全生命周期管理：从初始开发、Dev Notes 文档编写、QA 测试，到客户评审与生产发布，全流程独立交付',
-      '借助 GitHub Actions 自动化测试体系保障代码可靠性，持续维护技术文档',
-      '持续参与双层 Code Review，确保交付符合企业级工程规范',
-      '为 CoverMore 白标保险产品实现多步购买漏斗，设计支持多品牌定制的白标架构，单一代码库服务多个合作伙伴',
-    ],
     techStack: [
       'React 18',
       'Next.js',
@@ -92,11 +80,7 @@ export const workExperiences: WorkExperience[] = [
     role: 'Frontend Engineer · 前端工程师',
     location: '成都',
     body: '在青云科技负责云市场（Marketplace）前端研发，覆盖买家中心、卖家中心、订单管理、支付流程等核心业务链路，并主导企业官网的移动端响应式改版，积累了 ToB SaaS 产品的完整开发经验。',
-    highlights: [
-      '使用 React + TypeScript 端到端交付云市场买卖家中心功能，包括订单管理与支付流程',
-      '主导高流量营销落地页开发，使用 Next.js SSR 保障 SEO 效果与首屏性能，提升用户转化率',
-      '执行企业官网全面移动端优先响应式改版，确保跨设备无障碍访问体验',
-    ],
+
     techStack: ['React', 'TypeScript', 'Next.js', 'Ant Design', 'Sass', 'RESTful API'],
     illustrationKey: 'dataviz',
   },
@@ -110,11 +94,7 @@ export const workExperiences: WorkExperience[] = [
     role: 'Intern Frontend Engineer · 前端工程师',
     location: '成都',
     body: '职业生涯的起点。在鹏业软件深度参与跨平台 UI 框架的从零设计与研发，独立完成 Angular 框架搭建并发布为内部 npm 包，负责多角色动态仪表盘和复杂权限系统的实现。',
-    highlights: [
-      '使用 Angular 9 构建跨平台 UI 框架（PC + 微信小程序），封装为内部 npm 包供多项目复用',
-      '使用位运算实现读/写/审批/编辑的复杂权限控制体系，显著降低逻辑耦合度和内存开销',
-      '设计多角色动态仪表盘与全局搜索模块，实现关键词高亮和搜索历史功能',
-    ],
+
     techStack: ['Angular 9', 'TypeScript', 'WeChat Mini-program', 'npm Package', 'RxJS', 'Less'],
     illustrationKey: 'ecommerce',
   },
@@ -294,9 +274,9 @@ export const workShowcases: WorkShowcase[] = [
     categoryZh: '旅游平台',
     title: 'TravelAssociates',
     titleZh: 'TravelAssociates',
-    desc: 'End-to-end platform rebuild for a leading Australian travel brand — migrated the entire site to Next.js + Turborepo, delivering core features, a standardised component library, and Lighthouse SEO 100/100.',
+    desc: 'End-to-end platform rebuild for a leading Australian travel brand — migrated the entire site to Next.js + Turborepo, delivering core features, a standardised component library, and Lighthouse Performance 85/100 SEO 100/100.',
     descZh:
-      '主导澳大利亚头部旅游品牌全站重构——整体迁移至 Next.js + Turborepo，负责核心功能交付、组件库规范化建设，Lighthouse SEO 满分 100/100。',
+      '澳大利亚头部旅游品牌全站重构——整体迁移至 Next.js + Turborepo，负责核心功能交付、组件库规范化建设，Lighthouse Performance 85/100 SEO 100/100。',
     tech: ['Next.js', 'TypeScript', 'Turborepo'],
     coverImage: travelAssociatesImg,
     siteUrl: 'https://www.travelassociates.com',
@@ -307,7 +287,7 @@ export const workShowcases: WorkShowcase[] = [
     categoryZh: '设计系统',
     title: 'Flight Centre',
     titleZh: 'Flight Centre',
-    desc: "High-bar feature delivery within Flight Centre's Lerna monorepo — pixel-perfect Figma implementation, Drupal headless CMS integration, and an AWS Lambda + Elasticsearch BFF powering store search.",
+    desc: "High-bar feature delivery within Flight Centre's monorepo — pixel-perfect Figma implementation, Drupal headless CMS integration, and an AWS Lambda + Elasticsearch BFF powering store search.",
     descZh:
       '在 Flight Centre Lerna Monorepo 中高标准交付页面功能——像素级还原 Figma 设计，打通 Drupal Headless CMS，并集成 AWS Lambda + Elasticsearch BFF 驱动门店搜索。',
     tech: ['Next.js', 'FC Design System', 'Storybook', 'AWS Lambda', 'Jest'],
@@ -322,7 +302,7 @@ export const workShowcases: WorkShowcase[] = [
     titleZh: 'CoverMore',
     desc: 'Large-scale white-label insurance platform built on a Drupal PHP theme inheritance model — a base theme powering multiple partner sub-themes, ranging from legacy JavaScript to modern Preact. Delivered a multi-step purchase funnel adaptable across all brand variants.',
     descZh:
-      '基于 Drupal PHP 主题继承体系的大型白标保险平台——一套 base theme 驱动多个合作伙伴 sub-theme，技术栈横跨原生 JavaScript 老主题与现代 Preact 新主题，交付可跨品牌复用的多步购买漏斗。',
+      '基于 Drupal PHP 主题继承体系的大型白标保险平台——一套 base theme 驱动多个合作伙伴 sub-theme，技术栈横跨原生 JavaScript 老主题与现代 Preact 新主题，交付可跨品牌复用的多步购买流程。',
     tech: ['Drupal PHP Themes', 'Preact', 'JavaScript', 'Tailwind CSS'],
     slides: [
       { label: 'CoverMore', coverImage: coverMoreImg, siteUrl: 'https://www.covermore.com.au' },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow: /
+Allow: /

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,6 +17,7 @@ module.exports = {
         ink: {
           DEFAULT: '#1F1F1F',
           light: '#8A9B7C',
+          lt: '#919191',
         },
         olive: {
           DEFAULT: '#8E9B84',
@@ -29,9 +30,11 @@ module.exports = {
           ink: '#3D2A00',
         },
         dark: '#1A1F18',
-
         /* Legacy aliases */
-        cream: '#F0EFE9',
+        cream: {
+          DEFAULT: '#F0EFE9',
+          lt: '#E9EBEA',
+        },
         paper: '#F0EFE9',
         'warm-white': '#F0EFE9',
         midnight: '#1A1F18',
@@ -58,6 +61,10 @@ module.exports = {
           '51%': { transform: 'scaleY(1)', transformOrigin: 'bottom' },
           '100%': { transform: 'scaleY(0)', transformOrigin: 'bottom' },
         },
+        breathe: {
+          '0%, 100%': { opacity: '0.5', transform: 'scale(0.75)' },
+          '50%': { opacity: '1', transform: 'scale(1.25)' },
+        },
       },
       transitionDuration: {
         600: '600ms',
@@ -67,6 +74,7 @@ module.exports = {
         'fade-in': 'fadeIn 0.5s ease forwards',
         'skill-fill': 'skillFill 1s cubic-bezier(0.4, 0, 0.2, 1) forwards',
         'scroll-line': 'scrollLine 1.5s ease-in-out infinite',
+        breathe: 'breathe 2.4s ease-in-out infinite',
       },
     },
   },

--- a/types/index.ts
+++ b/types/index.ts
@@ -10,7 +10,6 @@ export interface WorkExperience {
   role: string;
   location: string;
   body: string;
-  highlights: string[];
   techStack: string[];
   illustrationKey: 'architecture' | 'dataviz' | 'ecommerce' | 'beginning';
 }


### PR DESCRIPTION
## Summary

- **Chatbot**: Add `ChatBot` component backed by a Dify API proxy route (`/api/chat`), with multi-turn conversation, avatar, loading animation, custom scrollbar, mobile-responsive panel width, and smooth icon toggle animation on the trigger button
- **Breathing dot animation**: Migrate `breathe` keyframe from `globals.css` to `tailwind.config.js` as the `animate-breathe` utility class; apply consistently in Nav and LifeSection mobile tabs — no more inline `style` or `motion` wrappers
- **Mobile Nav**: Add avatar image to the header left slot so it navigates home on tap, matching desktop behaviour
- **LifeSection mobile Curiosities**: Strip description text from flip-card back face, keeping only the bottom-left label — better fit for small screen card sizes
- **Copy updates**: CoverMore description reworded (购买漏斗 → 购买流程), Lighthouse scores corrected, `robots.txt` changed from `Disallow` to `Allow`
- **Design tokens**: Add missing `ink.lt` and `cream.lt` Tailwind color tokens

## Test plan

- [x] Open chatbot on desktop, send a message, verify Dify response renders correctly
- [x] On mobile, verify chatbot panel fits within viewport and background is fully opaque
- [x] Confirm Nav active dot and LifeSection tab indicator dot share the same breathing animation
- [x] On mobile, flip a Curiosities card and confirm only the label is shown on the back
- [x] `npm run lint && npm run type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)