### PR TITLE
refactor: remove unused vibeProjects data, simplify VibeProjectSection

### DIFF
--- a/components/section/VibeProjectSection.tsx
+++ b/components/section/VibeProjectSection.tsx
@@ -8,7 +8,6 @@ import { createPortal } from 'react-dom';
 
 import { useI18n } from '@/components/i18n/I18nProvider';
 import { Container } from '@/components/ui/Container';
-import { vibeProjects } from '@/lib/data';
 import pickleVibe11 from '@/public/images/vibeProjects/pickle-vibe-1-1.png';
 import pickleVibe1 from '@/public/images/vibeProjects/pickle-vibe-1.png';
 import pickleVibe2 from '@/public/images/vibeProjects/pickle-vibe-2.png';
@@ -166,7 +165,7 @@ function SelinMeCard() {
             />
           ))}
           <span className="ml-2 flex-1 rounded-full bg-ink/[0.06] px-2 py-0.5 text-center font-mono text-[0.38rem] text-ink/30">
-            selin-ma.github.io/selin-me
+            https://selin-me.vercel.app
           </span>
         </div>
 
@@ -225,7 +224,7 @@ function SelinMeCard() {
 
       {/* Link */}
       <a
-        href="https://selin-ma.github.io/selin-me"
+        href="https://selin-me.vercel.app"
         target="_blank"
         rel="noopener noreferrer"
         className="mt-4 inline-flex items-center gap-1 font-mono text-[0.57rem] uppercase tracking-[0.16em] text-[#6B8F71] transition-opacity duration-150 hover:opacity-60"
@@ -520,9 +519,7 @@ function VibeCard({ id }: { id: string }) {
 // ── Section ────────────────────────────────────────────────────────────────
 export function VibeProjectSection() {
   const { t } = useI18n();
-  const featured = vibeProjects
-    .filter((p) => FEATURED_IDS.includes(p.id))
-    .sort((a, b) => FEATURED_IDS.indexOf(a.id) - FEATURED_IDS.indexOf(b.id));
+  const featured = FEATURED_IDS;
 
   return (
     <section id="vibe" className="relative overflow-hidden bg-white pt-8 pb-4 md:py-20">
@@ -561,11 +558,11 @@ export function VibeProjectSection() {
       <Container className="hidden lg:block py-20">
         <div className="relative translate-y-20 min-h-[550px]">
           <ConnectorLines />
-          {featured.map((project, i) => {
+          {featured.map((id, i) => {
             const cfg = CARD_LAYOUT[i];
             return (
               <motion.div
-                key={project.id}
+                key={id}
                 className="absolute z-10 w-[26%] "
                 style={{ left: cfg.left, top: cfg.top, rotate: cfg.rotate }}
                 initial={{ opacity: 0, y: 30 }}
@@ -574,7 +571,7 @@ export function VibeProjectSection() {
                 transition={{ duration: 0.9, delay: 0.08 + i * 0.18, ease: [0.16, 1, 0.3, 1] }}
               >
                 <GlareCard>
-                  <VibeCard id={project.id} />
+                  <VibeCard id={id} />
                 </GlareCard>
               </motion.div>
             );
@@ -584,16 +581,16 @@ export function VibeProjectSection() {
 
       {/* Mobile: stacked */}
       <Container className="mt-10 space-y-6 pb-10 lg:hidden">
-        {featured.map((project, i) => (
+        {featured.map((id, i) => (
           <motion.div
-            key={project.id}
+            key={id}
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.65, delay: i * 0.1, ease: [0.16, 1, 0.3, 1] }}
           >
             <GlareCard>
-              <VibeCard id={project.id} />
+              <VibeCard id={id} />
             </GlareCard>
           </motion.div>
         ))}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -35,7 +35,6 @@ import type {
   OtherHobby,
   Skill,
   SportsActivity,
-  VibeProject,
   WorkExperience,
   WorkShowcase,
 } from '@/types';
@@ -340,70 +339,6 @@ export const workShowcases: WorkShowcase[] = [
   },
 ];
 
-export const vibeProjects: VibeProject[] = [
-  {
-    id: 'selin-me',
-    name: 'selin.me',
-    emoji: '🌿',
-    status: 'live',
-    color: '#6B8F71',
-    story:
-      '这个作品集本身就是一次 vibe coding 实验。从零开始，用 Claude 作为结对编程伙伴，在一周内完成了设计、开发、部署的全流程。每一行动画、每一个排版细节，都是人机协作的产物。',
-    desc: 'Selin的个人网站，用 AI 辅助开发。',
-    aiTools: ['Claude', 'v0'],
-    techStack: ['Next.js', 'Tailwind CSS', 'Framer Motion', 'TypeScript'],
-    liveUrl: 'https://selin-ma.github.io/selin-me',
-    repoUrl: 'https://github.com/selin-ma/selin-me',
-  },
-  {
-    id: 'pickle-vibe',
-    name: 'Pickle Vibe',
-    emoji: '🥒',
-    status: 'building',
-    color: '#C4714B',
-    story:
-      '匹克球在中国还是一项新兴运动，但它正在以惊人的速度生长。Pickle Vibe 是专为中文社区打造的匹克球内容平台——比赛资讯、技术教学、装备测评、球友社区，一站聚合。用 vibe coding 方式，把对这项运动的热爱变成一个真实产品。',
-    desc: '面向中文球友的匹克球内容平台，聚合赛事、教学与社区。',
-    aiTools: ['Claude', 'Cursor', 'v0'],
-    techStack: ['Next.js', 'TypeScript', 'Tailwind CSS', 'Supabase'],
-  },
-  {
-    id: 'pickle-tracker',
-    name: 'Pickle Tracker',
-    emoji: '📊',
-    status: 'building',
-    color: '#7A9DB5',
-    story:
-      '一个帮助匹克球玩家分析比赛回合的工具。记录每一分的得失原因，可视化自己的技术短板，找到真正需要练习的地方。从"感觉打得不好"到"数据告诉我哪里不好"。',
-    desc: '匹克球回合数据记录与分析工具，用数据找到技术提升点。',
-    aiTools: ['Claude', 'Cursor'],
-    techStack: ['React', 'TypeScript', 'Chart.js', 'PWA'],
-  },
-  {
-    id: 'cycle-log',
-    name: '月经记录',
-    emoji: '🌸',
-    status: 'building',
-    color: '#9B4D7E',
-    story:
-      '一个简洁、私密的月经周期记录微信小程序。市面上的同类产品要么广告太多，要么权限太贪，要么界面太复杂。我想做一个只做一件事、做好一件事的工具——记录、预测、理解自己的身体节律。',
-    desc: '简洁私密的微信小程序，记录周期、预测下次、理解身体。',
-    aiTools: ['Claude', 'Cursor'],
-    techStack: ['微信小程序', 'TypeScript', 'Vant Weapp'],
-  },
-  {
-    id: 'still-hearth',
-    name: 'Still Hearth',
-    emoji: '🏡',
-    status: 'concept',
-    color: '#8B6F47',
-    story:
-      '一款像素风格的独立游戏，关于一个人在废弃小屋里慢慢修缮生活的故事。没有战斗，没有排行榜，只有修复、种植、等待和时间流逝的安静感。灵感来自对"慢游戏"的渴望——有时候你只是需要一个可以喘口气的地方。',
-    desc: '像素风独立游戏，在废弃小屋里修复生活，慢慢的，安静的。',
-    aiTools: ['Claude', 'Midjourney', 'Cursor'],
-    techStack: ['Godot 4', 'GDScript', 'Aseprite'],
-  },
-];
 
 export const otherHobbies: OtherHobby[] = [
   {


### PR DESCRIPTION
## Summary

- Removed the `vibeProjects` array from `lib/data.ts` — it was only used to filter/sort by ID in `VibeProjectSection`, while all actual card content (text, layout, links) was independently handled by `SelinMeCard`, `PickleVibeCard`, and `StillHearthCard` components driven by i18n keys
- `VibeProjectSection` now iterates `FEATURED_IDS` directly, eliminating ~65 lines of stale data that had diverged from the i18n source of truth
- Updated selin.me URL in `SelinMeCard` from `selin-ma.github.io/selin-me` to `https://selin-me.vercel.app`

## Test plan

- [x] Vibe section renders all three cards correctly on desktop and mobile
- [x] Card links point to the correct URLs
- [x] `npm run type-check` passes
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)