### PR TITLE
Update kana-jump vibe card: FSRS, audio, tech stack & Netlify links

### DIFF
--- a/components/section/VibeProjectSection.tsx
+++ b/components/section/VibeProjectSection.tsx
@@ -83,9 +83,9 @@ type CardMeta = { accent: string; techStack: string[]; links?: LinkDef[] };
 const CARD_META: Record<CardId, CardMeta> = {
   'kana-jump': {
     accent: '#7FA2BF',
-    techStack: ['React', 'TypeScript', 'Supabase', 'PWA'],
+    techStack: ['React', 'TypeScript', 'Supabase', 'PWA', 'ts-fsrs', 'Vite'],
     links: [
-      { href: 'https://kana-jump.vercel.app/', label: 'Live', primary: true },
+      { href: 'https://kana-jump.netlify.app/', label: 'Live', primary: true },
       { href: 'https://github.com/selin-ma/kana-jump', label: 'GitHub', primary: false },
     ],
   },
@@ -93,7 +93,7 @@ const CARD_META: Record<CardId, CardMeta> = {
     accent: '#6B8F71',
     techStack: ['Next.js', 'TypeScript', 'Framer Motion', 'Tailwind'],
     links: [
-      { href: 'https://selin-me.vercel.app', label: 'Live', primary: true },
+      { href: 'https://selin-me.netlify.app', label: 'Live', primary: true },
       { href: 'https://github.com/selin-ma/selin-me', label: 'GitHub', primary: false },
     ],
   },
@@ -180,7 +180,7 @@ function SelinMeVisual() {
           <span key={c} className="h-[7px] w-[7px] rounded-full" style={{ background: c + '80' }} />
         ))}
         <span className="ml-2 flex-1 rounded-full bg-ink/[0.06] px-2 py-0.5 text-center font-mono text-[0.42rem] text-ink/30">
-          https://selin-me.vercel.app
+          https://selin-me.netlify.app
         </span>
       </div>
       {/* Mini nav */}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -335,7 +335,7 @@ export const workShowcases: WorkShowcase[] = [
     descZh:
       '你正在看的这个网站。以 Claude 为结对伙伴，一周内完成设计、开发与部署，双语 i18n + Framer Motion 动效。',
     tech: ['Next.js', 'Framer Motion', 'Tailwind'],
-    siteUrl: 'https://selin-ma.github.io/selin-me',
+    siteUrl: 'https://selin-me.netlify.app',
   },
 ];
 

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -184,7 +184,7 @@ export const messages: Record<Locale, Messages> = {
     'vibe.card.kanajump.category': 'Web App · 日语学习 · 更新中',
     'vibe.card.kanajump.title': 'Kana Jump',
     'vibe.card.kanajump.desc':
-      '一款专注于假名学习的 PWA 应用，支持离线使用、答题历史同步和错题针对性练习。',
+      '专注假名学习的 PWA 应用，搭载 FSRS 间隔重复算法与 R2 音频存储，按教材章节组织单词学习，智能调度复习节奏。',
 
     // Work Showcase
     'showcase.kicker': '工作成果',
@@ -377,7 +377,7 @@ export const messages: Record<Locale, Messages> = {
     'vibe.card.kanajump.category': 'Web App · Japanese',
     'vibe.card.kanajump.title': 'Kana Jump',
     'vibe.card.kanajump.desc':
-      'A kana memorization tool — browse hiragana & katakana, practice mode, and study history. Built as a PWA so it works anywhere.',
+      'A kana memorization PWA with FSRS spaced repetition, R2-hosted audio, and vocabulary organized by textbook chapters for smart review scheduling.',
 
     // Work Showcase
     'showcase.kicker': 'Selected Work',

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -184,7 +184,7 @@ export const messages: Record<Locale, Messages> = {
     'vibe.card.kanajump.category': 'Web App · 日语学习 · 更新中',
     'vibe.card.kanajump.title': 'Kana Jump',
     'vibe.card.kanajump.desc':
-      '专注假名学习的 PWA 应用，搭载 FSRS 间隔重复算法与 R2 音频存储，按教材章节组织单词学习，智能调度复习节奏。',
+      '专注日语学习的 PWA 应用，支持假名记忆与单词记忆，搭载 FSRS 间隔重复算法与 R2 音频存储，按《大家的日语初级 I》教材章节组织学习内容，智能调度复习节奏。',
 
     // Work Showcase
     'showcase.kicker': '工作成果',
@@ -377,7 +377,7 @@ export const messages: Record<Locale, Messages> = {
     'vibe.card.kanajump.category': 'Web App · Japanese',
     'vibe.card.kanajump.title': 'Kana Jump',
     'vibe.card.kanajump.desc':
-      'A kana memorization PWA with FSRS spaced repetition, R2-hosted audio, and vocabulary organized by textbook chapters for smart review scheduling.',
+      'A Japanese language learning PWA with kana memorization and vocabulary practice, powered by FSRS spaced repetition and R2-hosted audio. Organized by Minna no Nihongo I textbook chapters for smart review scheduling.',
 
     // Work Showcase
     'showcase.kicker': 'Selected Work',


### PR DESCRIPTION
### Summary

Updates the VibeProject card for kana-jump to reflect the latest development progress, and migrates all deployment links to Netlify.

### Changes

**i18n descriptions (`lib/i18n.ts`)**:
- **zh**: Added FSRS spaced repetition algorithm, R2 audio storage, and textbook chapter-based vocabulary organization
- **en**: Same updates in English — FSRS, R2 audio, vocabulary chapters

**Tech stack (`VibeProjectSection.tsx`)**: Added `ts-fsrs` and `Vite` to the kana-jump card meta

**URLs migrated from Vercel / GitHub Pages → Netlify**:
- kana-jump Live link: `vercel.app` → `netlify.app`
- selin-me Live link: `vercel.app` → `netlify.app`
- selin-me browser chrome mockup URL updated
- selin-me Work Showcase siteUrl updated (was GitHub Pages)

### Files changed
- `components/section/VibeProjectSection.tsx` — 4 URL/tech updates
- `lib/data.ts` — 1 URL update (selin-me showcase)
- `lib/i18n.ts` — 2 translation updates (zh + en)