### PR TITLE
fix: photo caption alignment and hobby label copy

### DIFF
--- a/components/section/LifeSectionMasonry.tsx
+++ b/components/section/LifeSectionMasonry.tsx
@@ -243,11 +243,11 @@ function SportsSection() {
                 )}
               </div>
               <div className="mt-2 flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-0.5 sm:gap-1 px-0.5">
-                <p className="font-dm-mono text-[0.6rem] sm:text-xs uppercase tracking-[0.1em] sm:tracking-[0.14em] text-ink/80 leading-tight text-center">
+                <p className="font-dm-mono text-[0.6rem] sm:text-xs uppercase tracking-[0.1em] sm:tracking-[0.14em] text-ink/80 leading-tight text-right sm:text-left">
                   {t(photo.labelKey)}
                 </p>
                 {photo.date && (
-                  <span className="shrink-0 font-dm-mono text-[0.6rem] sm:text-xs tracking-[0.06em] text-ink/60 sm:text-ink/80 text-center">
+                  <span className="shrink-0 font-dm-mono text-[0.6rem] sm:text-xs tracking-[0.06em] text-ink/60 sm:text-ink/80 text-right">
                     {formatPhotoDate(photo.date, t)}
                   </span>
                 )}

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -388,9 +388,9 @@ export const messages: Record<Locale, Messages> = {
     'life.hobby.surf-skate.label': 'Surf Skate',
     'life.hobby.surf-skate.desc':
       'Self-taught from scratch. Once I could glide steadily, I found myself cruising a 10 km greenway with friends — and conquering pump tracks that had once sent me flat on my back.',
-    'life.hobby.travel.label': 'Nature Explorer',
-    'life.hobby.tb.label': 'Team Outing Host',
-    'life.hobby.hiking.label': 'Occasional Hiker',
+    'life.hobby.travel.label': 'Traveling',
+    'life.hobby.tb.label': 'Hosting Team Outings',
+    'life.hobby.hiking.label': 'Hiking',
 
     // Sports photos
     'life.photo.kl1': 'MiLP · Kuala Lumpur',


### PR DESCRIPTION
## Summary

- **Caption alignment** (`LifeSectionMasonry.tsx`): polaroid photo captions in the Sports section were `text-center` on all breakpoints. Now `text-right` on mobile and `text-left sm:text-right` on desktop (sm+), matching the intended left-label / right-date flex layout.
- **Hobby labels** (`lib/i18n.ts`, `en` locale): rewrote three labels to use noun/gerund form for visual consistency with the rest of the hobby cards:
  - `Nature Explorer` → `Traveling`
  - `Team Outing Host` → `Hosting Team Outings`
  - `Occasional Hiker` → `Hiking`

## Test plan

- [ ] View Sports section on mobile — captions should be right-aligned under each polaroid
- [ ] View Sports section on desktop (≥640px) — event name left, date right
- [ ] Switch to English locale and check the "More / Curiosities" section — three updated hobby labels visible
- [ ] `npm run lint && npm run type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)